### PR TITLE
fix: migrate Tailwind CSS config from v3 to v4 syntax

### DIFF
--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -1,3 +1,13 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
+@source "../../src/**/*.html";
+
+@theme {
+  --color-spxp-dark: #0a0a0f;
+  --color-spxp-darker: #050508;
+  --color-spxp-accent: #6366f1;
+  --color-spxp-green: #22c55e;
+  --color-spxp-muted: #6b7280;
+  --font-sans: Inter, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+}


### PR DESCRIPTION
## Problem
After PR #49 replaced the Tailwind CDN with a pre-built CSS file, the site lost all styling for pages added in PR #51 (Why, How It Works, Ecosystem, Quickstart).

**Root cause:** Tailwind v4 (installed: v4.2.2) ignores `tailwind.config.js` entirely. The old `@tailwind` directives are v3 syntax. Without explicit `@source` directives, Tailwind v4 only scans a limited set of files — missing most utility classes used across the new subpages.

Live CSS was only **5.4 KB** (vs expected ~25 KB), missing classes like `text-white`, `bg-gray-800`, `bg-spxp-accent`, etc.

## Fix
Migrate `src/css/tailwind.css` to v4 syntax:
- Replace `@tailwind base/components/utilities` with `@import 'tailwindcss'`
- Add `@source` to explicitly scan `src/**/*.html`
- Migrate custom theme (colors, fonts) to `@theme` CSS variables (v4 standard)

## Result
CSS output: **5.4 KB → 25.9 KB** ✅  
All utility classes now generated correctly for all pages.