### PR TITLE
fix: serve subpages as subdir/index.html for clean URLs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,9 @@ function buildTailwind(done) {
 }
 
 // COMPILE HTML WITH PANINI
+// index.html stays at root; all other pages go into subfolders as index.html
+const rename = require('gulp-rename');
+
 function compileHTML() {
   console.log('---------------COMPILING HTML WITH PANINI---------------');
   panini.refresh();
@@ -32,6 +35,13 @@ function compileHTML() {
       partials: 'src/partials/',
       helpers: 'src/helpers/',
       data: 'src/data/'
+    }))
+    .pipe(rename(function(file) {
+      // Keep index.html at root, move others to subdir/index.html
+      if (file.basename !== 'index') {
+        file.dirname = file.basename;
+        file.basename = 'index';
+      }
     }))
     .pipe(dest('dist'))
     .pipe(browserSync.stream());
@@ -55,7 +65,7 @@ function copyStatic() {
 // PRETTIFY HTML FILES
 function prettyHTML() {
   console.log('---------------HTML PRETTIFY---------------');
-  return src('dist/*.html')
+  return src('dist/**/*.html')
     .pipe(prettyHtml({
       indent_size: 4,
       indent_char: ' ',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "del": "^6.1.1",
         "gulp": "^5.0.1",
         "gulp-pretty-html": "^2.0.10",
+        "gulp-rename": "^2.1.0",
         "panini": "^1.7.2",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.2"
@@ -3026,6 +3027,16 @@
       "dependencies": {
         "js-beautify": "^1.7.5",
         "through2": "^2.0.3"
+      }
+    },
+    "node_modules/gulp-rename": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.1.0.tgz",
+      "integrity": "sha512-dGuzuH8jQGqCMqC544IEPhs5+O2l+IkdoSZsgd4kY97M1CxQeI3qrmweQBIrxLBbjbe/8uEWK8HHcNBc3OCy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/gulp/node_modules/convert-source-map": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "del": "^6.1.1",
     "gulp": "^5.0.1",
     "gulp-pretty-html": "^2.0.10",
+    "gulp-rename": "^2.1.0",
     "panini": "^1.7.2",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2"


### PR DESCRIPTION
## Problem
`/ecosystem/` returns 404. The previous fix (MultiViews via .htaccess) doesn't work because IONOS doesn't allow `AllowOverride` for .htaccess files.

## Fix
Instead of deploying `ecosystem.html`, generate `ecosystem/index.html`. Apache serves these automatically when requesting `/ecosystem/`.

Changes:
- Add `gulp-rename` to move non-index pages into subdirectories
- Update `prettyHTML` to process `dist/**/*.html` (not just root level)

## Result
`/ecosystem/` ✅ `/quickstart/` ✅ `/why/` ✅ `/how-it-works/` ✅